### PR TITLE
Rename the link component props

### DIFF
--- a/src/components/FamilyTree/FamilyTree.tsx
+++ b/src/components/FamilyTree/FamilyTree.tsx
@@ -59,7 +59,7 @@ const FamilyTree = (props: FamilyTreeProps) => {
           )
       )}
       {hierarchyLinks.map((link) => (
-        <Link start={link.ParentNodeId} end={link.ChildNodeId} />
+        <Link parentNodeId={link.ParentNodeId} childNodeId={link.ChildNodeId} />
       ))}
     </div>
   );

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,15 +1,15 @@
 import Xarrow from "react-xarrows";
 
 type LinkProps = {
-  start: string;
-  end: string;
+  parentNodeId: string;
+  childNodeId: string;
 };
 
 const Link = (linkProps: LinkProps) => {
   return (
     <Xarrow
-      start={linkProps.start}
-      end={linkProps.end}
+      start={linkProps.parentNodeId}
+      end={linkProps.childNodeId}
       startAnchor="bottom"
       endAnchor={"top"}
       path={"grid"}


### PR DESCRIPTION
Rename the link component props so that they match the property names of a link